### PR TITLE
TAta Docomo

### DIFF
--- a/Tata Docomo
+++ b/Tata Docomo
@@ -1,0 +1,54 @@
+Tata Docomo
+
+Tools
+
+From Wikipedia, the free encyclopedia
+TATA DOCOMOTata Docomo Logo.png
+Formerly	Tata Docomo
+Type	Subsidiary
+Industry	Telecommunications
+Founded	November 2008; 14 years ago
+Defunct	1 July 2019; 3 years ago
+Fate	Acquired by Bharti Airtel
+Headquarters	Mumbai, Maharashtra, India
+Area served
+	India
+Products	
+
+    Mobile Telephony
+    Wireless Internet
+    Internet Services
+
+Owner	Bharti Airtel
+Members	20.04 million (March 2018)[1]
+Number of employees
+	5,015[2]
+Parent	Bharti Airtel
+
+Tata Docomo was an Indian mobile network operator, a wholly owned subsidiary of Tata Teleservices. In October 2017, Bharti Airtel announced a merger deal with Tata Teleservices and the acquisition of Tata Docomo.[3] As of 21 July 2019, all Tata Docomo users are merged with Airtel network and provided with all the Airtel services.
+
+The consumer mobile businesses of Tata Docomo, Tata Teleservices (TTSL) and Tata Teleservices Maharashtra Limited (TTML) have been merged into Bharti Airtel from 1 July 2019.[4][5][6]
+History
+Further information: Tata Group
+
+Tata Docomo was part of the Indian conglomerate Tata Group. The company received the licence to operate GSM services in nineteen telecom circles and was allotted spectrum in eighteen of these circles and launched GSM services on 24 June 2009. It began operations first in South India and currently operates GSM services in eighteen of twenty two telecom circles. It has licences to operate in Delhi but has not been allocated spectrum from the Government.[7] Docomo provides services throughout India. Tata Docomo offers both prepaid and postpaid cellular phone services. It has become very popular with its one-second pulse, especially in semi-urban and rural areas.
+
+In November 2008, NTT Docomo invested ₹12,740 crore (equivalent to ₹270 billion or US$3.4 billion in 2020) in Tata Teleservices, at ₹117 (equivalent to ₹250 or US$3.10 in 2020) a share for a 26.5% stake in the latter.[8][9] Docomo, TTSL and Tata Sons had in March 2009 signed shareholder agreement for the business alliance. In March 2009, Docomo acquired a 27.31% in Tata Teleservices for Rs 12,924 crore and 20.25% in Tata Teleservices (Maharashtra) Ltd, the listed arm of TTSL, for ₹949 crore. Overall, Docomo holds 26.5% in Tata Teleservices.[10]
+
+On 5 November 2010, Tata Docomo became the first private sector telecom company to launch 3G services in India. Tata Docomo had about 49 million users at the end of March 2017.
+
+In April 2011, Tata Docomo signed Bollywood actor Ranbir Kapoor as its brand ambassador on a three-year contract, now the contract is expired.[11] For the southern states of Tamil Nadu and Andhra Pradesh, actors Vijay and Ram Charan are the brand ambassadors respectively.
+
+In October 2017, Bharti Airtel announced its acquisition of Tata Docomo having roughly 17 million subscribers.[12]
+Rebranding & Reformation
+
+On 20 October 2011, the Tata Group brought its brands – Indicom (CDMA), Walky (Fixed Wireless Phone), Photon INTERNET – under the Tata Docomo brand. All subscribers to these services were transited to the Tata Docomo's network on 20 October 2011. In 2015, Virgin Mobile India company was merged with Tata Docomo. T24 Mobile company was merged with Tata Docomo on 15 August 2018.[13] All operations around these companies across India had merged into Tata Docomo's entity to form second largest CDMA and GSM network in India.
+NTT Docomo Exit
+
+According to the agreement between the Tata Group and NTT Docomo, the latter had the right to sell its stake if Tata Docomo missed performance targets, with Tata getting right of the first refusal.[9][14] On 25 April 2014, NTT Docomo had announced that they would sell all of their shares in Tata Docomo and exit the Indian telecom industry as they had incurred a total loss of $1.3 billion. Under the joint venture agreement between the two groups, NTT Docomo would either increase its stake from 26.5% to 51%, or sell all of its shares, depending on the performance of Tata Docomo in the Indian market.[15]
+
+Since Tata was unable to find a buyer for the shares, they sought the approval of the RBI, in November 2014, to buy back the shares from NTT Docomo for $1.1 billion (at ₹58.045 per share), half the price paid by them in 2009. The RBI had approved the deal in January 2015, but however, went back on their decision and rejected the deal in March 2015, citing FEMA regulations.[16] Following the RBI decision, the Tata Group offered to purchase Docomo's stake at ₹23.34 a share on the basis of a fair market value determined on 30 June 2014 by PwC.[9] NTT Docomo then moved the London Court of International Arbitration seeking a valuation of ₹58 a share.[17]
+
+On 28 February 2017, Tata and NTT Docomo resolved their dispute, after the former announced that it would pay the latter US$1.18 billion in exchange for NTT Docomo's shares in the joint venture.[18] On 31 October, $1.27 billion was paid to NTT Docomo by Tata Sons, thus ending the dispute.[19]
+Acquisition by Bharti Airtel
+On 12 October 2017, Bharti Airtel proposed a deal for the acquisition of Tata Group's Telecommunications including, Tata Teleservices and Tata Docomo. Tata Group made deal with Airtel, to sell its assets in debt-cash free deal which will only include TTSL's spectrum liability.[20] Competition Commission of India (CCI) and the Department of Telecom (DoT) gave approval for Airtel to proceed with the deal. 


### PR DESCRIPTION
 Indian mobile network operator, a wholly owned subsidiary of Tata Teleservices. In October 2017, Bharti Airtel announced a merger deal with Tata Teleservices and the acquisition of Tata Docomo.[3] As of 21 July 2019, all Tata Docomo users are merged with Airtel network and provided with all the Airtel services.

The consumer mobile businesses of Tata Docomo, Tata Teleservices (TTSL) and Tata Teleservices Maharashtra Limited (TTML) have been merged into Bharti Airtel from 1 July 2019